### PR TITLE
Convert all aimer radians names to rotations

### DIFF
--- a/src/main/java/frc/robot/constants/ScoringConstants.java
+++ b/src/main/java/frc/robot/constants/ScoringConstants.java
@@ -41,27 +41,22 @@ public class ScoringConstants {
 
     public static final double kickerIntakeVolts = 2.0;
 
-    public static final double aimPositionTolerance = 0.003;
+    // public static final double aimPositionTolerance = 0.003;
 
-    // These values have been reduced for tuning because we can't set a voltage limit on the motors
-    // anymore
-    // public static final double aimerAcceleration = 4.5; // TODO: 15.0
-    // public static final double aimerCruiseVelocity = 7.0; // TODO: 15.0
-    public static final double aimerAcceleration = 3.5; // 0.7;
-    public static final double aimerCruiseVelocity = 0.8; // 0.4;
+    public static final double aimerAcceleration = 3.5;
+    public static final double aimerCruiseVelocity = 0.8;
 
     public static final double shooterLowerVelocityMarginRPM = 50;
     public static final double shooterUpperVelocityMarginRPM = 150;
-    public static final double aimAngleMarginRadians = Units.degreesToRadians(1);
-    public static final double aimAngleVelocityMargin = 2.0; // Units.degreesToRadians(5);
+    public static final double aimAngleMarginRotations = Units.degreesToRotations(1);
+    public static final double aimAngleVelocityMargin = 2.0;
 
-    public static final double intakeAngleToleranceRadians = 0.05;
-    // Math.PI / 2 - Units.degreesToRadians(40);
+    public static final double intakeAngleToleranceRotations = 0.05; // Todo: tune this value
 
     public static final double shooterAmpVelocityRPM = 2000;
 
-    public static final double aimMaxAngleRadians = 0.361328 - 0.184570; // Math.PI / 2
-    public static final double aimMinAngleRadians = -0.195; // -0.037598 - 0.184570;
+    public static final double aimMaxAngleRotations = 0.361328 - 0.184570;
+    public static final double aimMinAngleRotations = -0.195;
     public static final double aimAngleTolerance = 0.015;
 
     public static final double maxAimIntake = 0.0;
@@ -74,7 +69,7 @@ public class ScoringConstants {
 
     // NOTE - This should be monotonically increasing
     // Key - Distance in meters
-    // Value - Aimer angle in radians
+    // Value - Aimer angle in rotations
     public static HashMap<Double, Double> getAimerMap() {
         HashMap<Double, Double> map = new HashMap<Double, Double>();
         map.put(0.0, -0.084);
@@ -115,10 +110,10 @@ public class ScoringConstants {
 
     // NOTE - This should be monotonically increasing
     // Key - Distance to goal in meters
-    // Value - Aimer angle tolerance in radians
+    // Value - Aimer angle tolerance in rotations
     public static HashMap<Double, Double> aimerToleranceTable() {
         HashMap<Double, Double> map = new HashMap<Double, Double>();
-        map.put(0.0, 0.003);
+        map.put(0.0, 0.003); // Todo: tune this value after conversion from radians to rotations
 
         return map;
     }

--- a/src/main/java/frc/robot/subsystems/scoring/AimerIO.java
+++ b/src/main/java/frc/robot/subsystems/scoring/AimerIO.java
@@ -5,15 +5,15 @@ import org.littletonrobotics.junction.AutoLog;
 public interface AimerIO {
     @AutoLog
     public static class AimerInputs {
-        public double aimAngleRad = 0.0;
-        public double aimGoalAngleRad = 0.0;
-        public double aimProfileGoalAngleRad = 0.0;
+        public double aimAngleRot = 0.0;
+        public double aimGoalAngleRot = 0.0;
+        public double aimProfileGoalAngleRot = 0.0;
 
         public double aimStatorCurrentAmps = 0.0;
         public double aimSupplyCurrentAmps = 0.0;
 
-        public double aimVelocityRadPerSec = 0.0;
-        public double aimVelocityErrorRadPerSec = 0.0;
+        public double aimVelocityRotPerSec = 0.0;
+        public double aimVelocityErrorRotPerSec = 0.0;
     }
 
     @AutoLog
@@ -25,11 +25,11 @@ public interface AimerIO {
 
     public default void applyOutputs(AimerOutputs outputs) {}
 
-    public default void setAimAngleRad(double angle) {}
+    public default void setAimAngleRot(double angle) {}
 
-    public default void controlAimAngleRad() {}
+    public default void controlAimAngleRot() {}
 
-    public default void setAngleClampsRad(double min, double max) {}
+    public default void setAngleClampsRot(double min, double max) {}
 
     public default void setOverrideMode(boolean override) {}
 

--- a/src/main/java/frc/robot/subsystems/scoring/AimerIORoboRio.java
+++ b/src/main/java/frc/robot/subsystems/scoring/AimerIORoboRio.java
@@ -42,7 +42,7 @@ public class AimerIORoboRio implements AimerIO {
     double minAngleClamp = 0.0;
     double maxAngleClamp = 0.0;
 
-    double goalAngleRad = 0.0;
+    double goalAngleRot = 0.0;
     double appliedVolts = 0.0;
 
     double velocity = 0.0;
@@ -99,36 +99,36 @@ public class AimerIORoboRio implements AimerIO {
     public void resetPID() {}
 
     @Override
-    public void setAimAngleRad(double goalAngleRad) {
-        this.goalAngleRad = goalAngleRad;
+    public void setAimAngleRot(double goalAngleRot) {
+        this.goalAngleRot = goalAngleRot;
     }
 
     @Override
-    public void controlAimAngleRad() {
-        if (goalAngleRad != previousGoalAngle) {
+    public void controlAimAngleRot() {
+        if (goalAngleRot != previousGoalAngle) {
             timer.reset();
             timer.start();
 
-            previousGoalAngle = goalAngleRad;
+            previousGoalAngle = goalAngleRot;
         }
-        goalAngleRad = MathUtil.clamp(goalAngleRad, minAngleClamp, maxAngleClamp);
+        goalAngleRot = MathUtil.clamp(goalAngleRot, minAngleClamp, maxAngleClamp);
     }
 
     @Override
-    public void setAngleClampsRad(double minAngleClamp, double maxAngleClamp) {
+    public void setAngleClampsRot(double minAngleClamp, double maxAngleClamp) {
         if (minAngleClamp > maxAngleClamp) {
             return;
         }
         this.minAngleClamp =
                 MathUtil.clamp(
                         minAngleClamp,
-                        ScoringConstants.aimMinAngleRadians,
-                        ScoringConstants.aimMaxAngleRadians);
+                        ScoringConstants.aimMinAngleRotations,
+                        ScoringConstants.aimMaxAngleRotations);
         this.maxAngleClamp =
                 MathUtil.clamp(
                         maxAngleClamp,
-                        ScoringConstants.aimMinAngleRadians,
-                        ScoringConstants.aimMaxAngleRadians);
+                        ScoringConstants.aimMinAngleRotations,
+                        ScoringConstants.aimMaxAngleRotations);
     }
 
     @Override
@@ -207,19 +207,19 @@ public class AimerIORoboRio implements AimerIO {
 
         Logger.recordOutput("Scoring/motorDisabled", motorDisabled);
 
-        inputs.aimGoalAngleRad = goalAngleRad;
-        inputs.aimProfileGoalAngleRad = controlSetpoint;
-        inputs.aimAngleRad = getEncoderPosition();
+        inputs.aimGoalAngleRot = goalAngleRot;
+        inputs.aimProfileGoalAngleRot = controlSetpoint;
+        inputs.aimAngleRot = getEncoderPosition();
 
         double currentTime = Utils.getCurrentTimeSeconds();
         double diffTime = currentTime - lastTime;
         lastTime = currentTime;
 
-        inputs.aimVelocityRadPerSec = (getEncoderPosition() - lastPosition) / diffTime;
+        inputs.aimVelocityRotPerSec = (getEncoderPosition() - lastPosition) / diffTime;
         velocity = (getEncoderPosition() - lastPosition) / diffTime;
         lastPosition = getEncoderPosition();
 
-        inputs.aimVelocityErrorRadPerSec =
+        inputs.aimVelocityErrorRotPerSec =
                 ((getEncoderPosition() - controlSetpoint) - lastError) / diffTime;
         lastError = getEncoderPosition() - controlSetpoint;
 
@@ -230,7 +230,7 @@ public class AimerIORoboRio implements AimerIO {
     @Override
     public void applyOutputs(AimerOutputs outputs) {
         MotionMagicVoltage motionMagicVoltage = new MotionMagicVoltage(0.0);
-        motionMagicVoltage.withPosition(goalAngleRad);
+        motionMagicVoltage.withPosition(goalAngleRot);
 
         request = motionMagicVoltage;
 


### PR DESCRIPTION
Rename aimer variables that indicated radians to indicate rotations, as our aimer now uses rotations as units.

- Rename all variables involving radians for the aimer in ScoringConstants, AimerIO, AimerIORoboRio, and AimerIOSim.
- Change aimer sim to use rotations internally as well (all radian values from the arm sim are converted to rotations before being stored in the IO).