### PR TITLE
Ignore isDriveAligned when against subwoofer

### DIFF
--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -2,5 +2,5 @@
     "enableCppIntellisense": false,
     "currentLanguage": "java",
     "projectYear": "2024",
-    "teamNumber": 9998
+    "teamNumber": 401
 }

--- a/src/main/deploy/pathplanner/autos/Amp Side - 2 Note.auto
+++ b/src/main/deploy/pathplanner/autos/Amp Side - 2 Note.auto
@@ -1,6 +1,12 @@
 {
   "version": 1.0,
-  "startingPose": null,
+  "startingPose": {
+    "position": {
+      "x": 0.7071301441350655,
+      "y": 6.711356821640298
+    },
+    "rotation": -118.17859010995917
+  },
   "command": {
     "type": "sequential",
     "data": {
@@ -18,15 +24,9 @@
           }
         },
         {
-          "type": "named",
+          "type": "wait",
           "data": {
-            "name": "waitForAlignment"
-          }
-        },
-        {
-          "type": "named",
-          "data": {
-            "name": "stopAlignToSpeaker"
+            "waitTime": 1.0
           }
         },
         {
@@ -40,18 +40,31 @@
                 }
               },
               {
-                "type": "named",
+                "type": "sequential",
                 "data": {
-                  "name": "intakeNote"
+                  "commands": [
+                    {
+                      "type": "wait",
+                      "data": {
+                        "waitTime": 0.5
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "intakeNote"
+                      }
+                    },
+                    {
+                      "type": "wait",
+                      "data": {
+                        "waitTime": 1.0
+                      }
+                    }
+                  ]
                 }
               }
             ]
-          }
-        },
-        {
-          "type": "named",
-          "data": {
-            "name": "alignToSpeaker"
           }
         },
         {
@@ -61,15 +74,53 @@
           }
         },
         {
-          "type": "named",
+          "type": "wait",
           "data": {
-            "name": "waitForAlignment"
+            "waitTime": 1.0
+          }
+        },
+        {
+          "type": "parallel",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "C1-W1"
+                }
+              },
+              {
+                "type": "sequential",
+                "data": {
+                  "commands": [
+                    {
+                      "type": "wait",
+                      "data": {
+                        "waitTime": 1.5
+                      }
+                    },
+                    {
+                      "type": "named",
+                      "data": {
+                        "name": "intakeNote"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "W1-Wing"
           }
         },
         {
           "type": "named",
           "data": {
-            "name": "stopAlignToSpeaker"
+            "name": "shootNoteAtSpeaker"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/paths/C1-W1.path
+++ b/src/main/deploy/pathplanner/paths/C1-W1.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 0.7071301441350655,
-        "y": 6.711356821640298
+        "x": 2.909982492594682,
+        "y": 7.0050704681015805
       },
       "prevControl": null,
       "nextControl": {
-        "x": 1.707130144135071,
-        "y": 6.711356821640298
+        "x": 4.3932364072241565,
+        "y": 7.401583890824312
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 2.8806111279485536,
-        "y": 6.990384785778517
+        "x": 8.62271291626662,
+        "y": 7.445640937793504
       },
       "prevControl": {
-        "x": 1.8806111279485536,
-        "y": 6.990384785778517
+        "x": 7.62271291626662,
+        "y": 7.445640937793504
       },
       "nextControl": null,
       "isLocked": false,
@@ -45,7 +45,7 @@
   "reversed": false,
   "folder": null,
   "previewStartingState": {
-    "rotation": -119.74488129694224,
+    "rotation": -154.88516511385532,
     "velocity": 0
   },
   "useDefaultConstraints": true

--- a/src/main/deploy/pathplanner/paths/W1-Wing.path
+++ b/src/main/deploy/pathplanner/paths/W1-Wing.path
@@ -3,25 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 0.7071301441350655,
-        "y": 6.711356821640298
+        "x": 8.593341551620492,
+        "y": 7.460326620116567
       },
       "prevControl": null,
       "nextControl": {
-        "x": 1.707130144135071,
-        "y": 6.711356821640298
+        "x": 6.302375109222491,
+        "y": 7.342841161532054
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 2.8806111279485536,
-        "y": 6.990384785778517
+        "x": 4.451979136516414,
+        "y": 6.241414987302248
       },
       "prevControl": {
-        "x": 1.8806111279485536,
-        "y": 6.990384785778517
+        "x": 5.700262133976863,
+        "y": 7.328155479208992
       },
       "nextControl": null,
       "isLocked": false,
@@ -45,7 +45,7 @@
   "reversed": false,
   "folder": null,
   "previewStartingState": {
-    "rotation": -119.74488129694224,
+    "rotation": 180.0,
     "velocity": 0
   },
   "useDefaultConstraints": true

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,7 +8,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
-import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
@@ -86,12 +85,13 @@ public class RobotContainer {
         NamedCommands.registerCommand(
                 "intakeNote",
                 // intakes to start, ends by setting action to NONE when intake subsystem has note
-                new FunctionalCommand(
-                        () -> intakeSubsystem.run(IntakeAction.INTAKE),
-                        () -> {},
-                        interrupted -> intakeSubsystem.run(IntakeAction.NONE),
-                        () -> scoringSubsystem.hasNote(),
-                        intakeSubsystem));
+                new InstantCommand(
+                        () -> {
+                            intakeSubsystem.run(IntakeAction.INTAKE);
+                            scoringSubsystem.setAction(ScoringAction.INTAKE);
+                        },
+                        intakeSubsystem,
+                        scoringSubsystem));
 
         NamedCommands.registerCommand(
                 "waitForAlignment",

--- a/src/main/java/frc/robot/constants/ScoringConstants.java
+++ b/src/main/java/frc/robot/constants/ScoringConstants.java
@@ -4,8 +4,8 @@ import edu.wpi.first.math.util.Units;
 import java.util.HashMap;
 
 public class ScoringConstants {
-    public static final double aimerkP = 85.0;
-    public static final double aimerkI = 0.0; // 5.0
+    public static final double aimerkP = 100.0;
+    public static final double aimerkI = 2.0; // 5.0
     public static final double aimerkD = 0.0;
 
     public static final double aimerkS = 0.3; // 0.25;

--- a/src/main/java/frc/robot/constants/ScoringConstants.java
+++ b/src/main/java/frc/robot/constants/ScoringConstants.java
@@ -52,6 +52,8 @@ public class ScoringConstants {
     public static final double aimAngleMarginRotations = Units.degreesToRotations(1);
     public static final double aimAngleVelocityMargin = 2.0;
 
+    public static final double minDistanceAlignmentNeeded = 1.3; // TODO: Tune this value
+
     public static final double intakeAngleToleranceRotations = 0.05; // Todo: tune this value
 
     public static final double aimerAmpPositionRot = 0.14;

--- a/src/main/java/frc/robot/subsystems/drive/PhoenixDrive.java
+++ b/src/main/java/frc/robot/subsystems/drive/PhoenixDrive.java
@@ -161,8 +161,8 @@ public class PhoenixDrive extends SwerveDrivetrain implements Subsystem {
                     this.setGoalSpeeds(speeds, false);
                 },
                 new HolonomicPathFollowerConfig(
-                        new PIDConstants(1),
-                        new PIDConstants(1, 0, 0),
+                        new PIDConstants(0.1),
+                        new PIDConstants(0.1, 0, 0),
                         PhoenixDriveConstants.kSpeedAt12VoltsMps,
                         driveBaseRadius,
                         new ReplanningConfig(false, false)),

--- a/src/main/java/frc/robot/subsystems/scoring/AimerIORoboRio.java
+++ b/src/main/java/frc/robot/subsystems/scoring/AimerIORoboRio.java
@@ -76,6 +76,7 @@ public class AimerIORoboRio implements AimerIO {
         talonFXConfigs.Feedback.SensorToMechanismRatio =
                 ScoringConstants.aimerEncoderToMechanismRatio;
         talonFXConfigs.Feedback.RotorToSensorRatio = ScoringConstants.aimerRotorToSensorRatio;
+        talonFXConfigs.MotorOutput.NeutralMode = NeutralModeValue.Brake;
 
         Slot0Configs slot0Configs = talonFXConfigs.Slot0;
         slot0Configs.GravityType = GravityTypeValue.Arm_Cosine;

--- a/src/main/java/frc/robot/subsystems/scoring/ScoringSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/scoring/ScoringSubsystem.java
@@ -250,7 +250,9 @@ public class ScoringSubsystem extends SubsystemBase implements Tunable {
                                 < aimerAngleTolerance.getValue(distanceToGoal)
                         && Math.abs(aimerInputs.aimVelocityErrorRotPerSec)
                                 < ScoringConstants.aimAngleVelocityMargin;
-        boolean driveReady = driveAlignedSupplier.get();
+        boolean driveReady =
+                (driveAlignedSupplier.get()
+                        || distanceToGoal < ScoringConstants.minDistanceAlignmentNeeded);
         boolean fieldLocationReady = true;
 
         if (!DriverStation.getAlliance().isPresent()) {


### PR DESCRIPTION
**Purpose**
When the robot is positioned against the subwoofer, it sometimes can't rotate and therefore sometimes can never be satisfied to auto-shoot. This means that mashers will have to force shoot when taking subwoofer shots and the robot might not be able to shoot preload when not starting from the middle position.

**Project Scope**
- [ ] Test whether or not this is actually a problem or if we can consistently manually align the robot before autonomous
- [ ] If it's an issue, determine a distance below which isDriveAligned should be ignored and driveReady should always be true.
- [ ] Test to make sure this doesn't cause is to prematurely shoot easy shots and miss.
